### PR TITLE
Add dependabot to whitelist

### DIFF
--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -14,7 +14,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        whitelist: "LPGhatguy,ZoteTheMighty,cliffchapmanrbx,MagiMaster,MisterUncloaked,amatosov-rbx"
+        whitelist: "LPGhatguy,ZoteTheMighty,cliffchapmanrbx,MagiMaster,MisterUncloaked,amatosov-rbx,dependabot[bot]"
         use-remote-repo: true
         remote-repo-name: "roblox/cla-bot-store"
         remote-repo-pat: ${{ secrets.CLA_REMOTE_REPO_PAT }}


### PR DESCRIPTION
Adds dependabot to the CLA whiltelist, making it easier to accept automated PRs for security updates.