### PR TITLE
add working dir support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: Test setup-foreman action
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
@@ -20,17 +21,31 @@ jobs:
     - run: npm run all
     - run: npm run pack
 
-    - uses: ./
+    - name: setup-foreman
+      uses: ./
       with:
         version: "*"
         token: ${{ secrets.GITHUB_TOKEN }}
     - run: foreman --version
     - run: rojo --version
 
-    - name: Install with working-directory
+  build-in-dir:
+    name: Test setup-foreman action with working-directory
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm install
+    - run: npm run all
+    - run: npm run pack
+    - name: setup-foreman with working-directory
       uses: ./
       with:
         version: "*"
         token: ${{ secrets.GITHUB_TOKEN }}
         working-directory: tests
+    - run: foreman --version
     - run: selene --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,18 @@ jobs:
     - run: npm install
     - run: npm run all
     - run: npm run pack
+
     - uses: ./
       with:
         version: "*"
         token: ${{ secrets.GITHUB_TOKEN }}
     - run: foreman --version
     - run: rojo --version
+
+    - name: Install with working-directory
+      uses: ./
+      with:
+        version: "*"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: tests
+    - run: selene --version

--- a/README.md
+++ b/README.md
@@ -22,5 +22,10 @@ A SemVer version range of Foreman to install.
 
 If not specified, the latest stable release will be installed.
 
+#### `working-directory` (optional)
+A working directory in which `foreman install` will be executed.
+
+If not specified the root job folder will be used
+
 ## License
 setup-foreman is available under the MIT license. See [LICENSE.txt](LICENSE.txt) or <https://opensource.org/licenses/MIT> for details.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ author: 'The Rojo Developers'
 inputs:
   version:
     description: 'SemVer version of Foreman to install'
+  working-directory:
+    description: 'Working directory to run `foreman install`` in'
   token:
     description: 'GitHub token from secrets.GITHUB_TOKEN'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: 'SemVer version of Foreman to install'
   working-directory:
     required: false
-    description: 'Working directory to run `foreman install`` in'
+    description: 'Working directory to run `foreman install` in'
   token:
     required: true
     description: 'GitHub token from secrets.GITHUB_TOKEN'

--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,13 @@ description: 'Install Foreman, a toolchain manager for Roblox projects'
 author: 'The Rojo Developers'
 inputs:
   version:
+    required: false
     description: 'SemVer version of Foreman to install'
   working-directory:
+    required: false
     description: 'Working directory to run `foreman install`` in'
   token:
+    required: true
     description: 'GitHub token from secrets.GITHUB_TOKEN'
 runs:
   using: 'node12'

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,9 +8,14 @@ async function run(): Promise<void> {
   try {
     const versionReq: string = core.getInput("version");
     const githubToken: string = core.getInput("token");
+    const workingDir: string = core.getInput("working-directory");
 
     const octokit = new github.GitHub(githubToken);
     const releases = await foreman.getReleases(octokit);
+
+    if (workingDir !== undefined && workingDir !== null && workingDir !== "") {
+      process.chdir(workingDir);
+    }
 
     core.debug("Choosing release from GitHub API");
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,10 +13,6 @@ async function run(): Promise<void> {
     const octokit = new github.GitHub(githubToken);
     const releases = await foreman.getReleases(octokit);
 
-    if (workingDir !== undefined && workingDir !== null && workingDir !== "") {
-      process.chdir(workingDir);
-    }
-
     core.debug("Choosing release from GitHub API");
 
     const release = foreman.chooseRelease(versionReq, releases);
@@ -46,8 +42,12 @@ async function run(): Promise<void> {
     }
 
     await foreman.authenticate(githubToken);
-    await foreman.installTools();
     foreman.addBinDirToPath();
+
+    if (workingDir !== undefined && workingDir !== null && workingDir !== "") {
+      process.chdir(workingDir);
+    }
+    await foreman.installTools();
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
 import * as github from "@actions/github";
+import {resolve} from 'path';
 import {exec} from "@actions/exec";
 import foreman from "./foreman";
 
@@ -35,7 +36,7 @@ async function run(): Promise<void> {
 
     const zipPath = await tc.downloadTool(asset.browser_download_url);
     const extractedPath = await tc.extractZip(zipPath, ".foreman-install");
-    core.addPath(extractedPath);
+    core.addPath(resolve(extractedPath));
 
     if (process.platform === "darwin" || process.platform === "linux") {
       await exec("chmod +x .foreman-install/foreman");

--- a/tests/foreman.toml
+++ b/tests/foreman.toml
@@ -1,0 +1,4 @@
+# This file is used as a way to make sure that setup-foreman is functioning.
+
+[tools]
+selene = { source = "Kampfkarren/selene", version = "0.15.0" }


### PR DESCRIPTION
Add new `working-direcotry` parameter that can be used to change working directory where `foreman install` is run
This change is needed for CIs that checkout into non default folder, e.g. [journey-to-rbxp.yaml](https://github.com/Roblox/lua-apps/blob/master/.github/workflows/journey-to-rbxp.yaml) in lua-apps
