### PR TITLE
feat: default token to github.token

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Add a step to your workflow file:
 #### `token` (required)
 A GitHub token used to interact with the GitHub API. This is used for installing Foreman itself, and then passed to Foreman to install other tools from GitHub.
 
+Defaults to `${{ github.token }}`
+
 #### `version` (optional)
 A SemVer version range of Foreman to install.
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,8 @@ inputs:
     description: 'Working directory to run `foreman install` in'
   token:
     required: true
-    description: 'GitHub token from secrets.GITHUB_TOKEN'
+    description: 'GitHub Personal Access Token. Defaults to github.token'
+    default: ${{ github.token }}
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Defaults the token input to `github.token` so that it doesn't have to be specified anymore when using the action.