### PR TITLE
APT-606 - Change Foreman To Install Internal Mirrors Instead Of External Tools

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -2,4 +2,4 @@
 
 [tools]
 rojo = { source = "Roblox/rojo", version = "0.6.0-alpha.1" }
-selene = { source = "Kampfkarren/selene", version = "0.15.0" }
+selene = { source = "Roblox/Kampfkarren-selene", version = "0.15.0" }

--- a/foreman.toml
+++ b/foreman.toml
@@ -2,4 +2,4 @@
 
 [tools]
 rojo = { source = "Roblox/rojo", version = "0.6.0-alpha.1" }
-selene = { source = "Roblox/Kampfkarren-selene", version = "0.15.0" }
+selene = { source = "Roblox/Kampfkarren-selene", version = "0.25.0" }

--- a/tests/foreman.toml
+++ b/tests/foreman.toml
@@ -1,4 +1,4 @@
 # This file is used as a way to make sure that setup-foreman is functioning.
 
 [tools]
-selene = { source = "Roblox/Kampfkarren-selene", version = "0.15.0" }
+selene = { source = "Roblox/Kampfkarren-selene", version = "0.25.0" }

--- a/tests/foreman.toml
+++ b/tests/foreman.toml
@@ -1,4 +1,4 @@
 # This file is used as a way to make sure that setup-foreman is functioning.
 
 [tools]
-selene = { source = "Kampfkarren/selene", version = "0.15.0" }
+selene = { source = "Roblox/Kampfkarren-selene", version = "0.15.0" }


### PR DESCRIPTION
Foreman should install from internal mirrors instead of arbitrary binaries from external github releases

[_Created by Sourcegraph batch change `afujiwara/APT-606-changing-external-tool-dependencies-to-internal-mirrors-foreman`._](https://sourcegraph.rbx.com/users/afujiwara/batch-changes/APT-606-changing-external-tool-dependencies-to-internal-mirrors-foreman)