### PR TITLE
Filter Release Tags

### DIFF
--- a/__tests__/configFile.test.ts
+++ b/__tests__/configFile.test.ts
@@ -1,8 +1,7 @@
 import configFile from "../src/configFile";
 import foreman from "../src/foreman";
-import type { GitHubRelease } from "../src/foreman";
-import { parse } from "toml";
-import semver from "semver";
+import type {GitHubRelease} from "../src/foreman";
+import {parse} from "toml";
 test("get off my back, Jest", () => {
   expect(5).toEqual(5);
 });

--- a/__tests__/configFile.test.ts
+++ b/__tests__/configFile.test.ts
@@ -1,7 +1,7 @@
 import configFile from "../src/configFile";
 import foreman from "../src/foreman";
-import type {GitHubRelease} from "../src/foreman";
-import {parse} from "toml";
+import type { GitHubRelease } from "../src/foreman";
+import { parse } from "toml";
 test("get off my back, Jest", () => {
   expect(5).toEqual(5);
 });
@@ -52,6 +52,10 @@ test("filter valid releases", () => {
     },
     {
       tag_name: "4.3.0",
+      assets: []
+    },
+    {
+      tag_name: "verybadtag",
       assets: []
     }
   ];

--- a/__tests__/configFile.test.ts
+++ b/__tests__/configFile.test.ts
@@ -1,6 +1,8 @@
 import configFile from "../src/configFile";
-import {parse} from "toml";
-
+import foreman from "../src/foreman";
+import type { GitHubRelease } from "../src/foreman";
+import { parse } from "toml";
+import semver from "semver";
 test("get off my back, Jest", () => {
   expect(5).toEqual(5);
 });
@@ -29,4 +31,46 @@ test("checkSameOrgToolSpec different org", () => {
   expect(configFile.checkSameOrgToolSpecs(manifestContent, "org1")).toEqual(
     false
   );
+});
+
+test("filter valid releases", () => {
+  const releases: GitHubRelease[] = [
+    {
+      tag_name: "v1.0.0",
+      assets: []
+    },
+    {
+      tag_name: "v2.1.0",
+      assets: []
+    },
+    {
+      tag_name: "v3.0.0-rc.1",
+      assets: []
+    },
+    {
+      tag_name: "notvalidsemver",
+      assets: []
+    },
+    {
+      tag_name: "4.3.0",
+      assets: []
+    }
+  ];
+
+  const expectedFilteredReleases: GitHubRelease[] = [
+    {
+      tag_name: "v1.0.0",
+      assets: []
+    },
+    {
+      tag_name: "v2.1.0",
+      assets: []
+    },
+    {
+      tag_name: "v3.0.0-rc.1",
+      assets: []
+    }
+  ];
+  const filteredReleases = foreman.filterValidReleases(releases);
+  expect(filteredReleases).toEqual(expectedFilteredReleases);
 });

--- a/src/configFile.ts
+++ b/src/configFile.ts
@@ -1,5 +1,5 @@
-import { parse } from "toml";
-import { readFile } from "fs";
+import {parse} from "toml";
+import {readFile} from "fs";
 import findUp from "find-up";
 interface foremanConfig {
   tools: {
@@ -58,7 +58,9 @@ async function checkSameOrgInConfig(org: string): Promise<void> {
 
   await readFile(manifestPath, "utf8", (err, data) => {
     if (err) {
-      throw new Error(`setup-foreman Could not read Foreman config file. err: ${err}`);
+      throw new Error(
+        `setup-foreman Could not read Foreman config file. err: ${err}`
+      );
     }
     const manifestContent = parse(data);
     const sameGithubOrgSource = checkSameOrgToolSpecs(manifestContent, org);

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -20,10 +20,18 @@ async function getReleases(octokit: GitHub): Promise<GitHubRelease[]> {
     repo: "foreman"
   });
 
-  const releases = response.data as GitHubRelease[];
+  let releases = response.data as GitHubRelease[];
+  releases = filterValidReleases(releases);
   releases.sort((a, b) => -semver.compare(a.tag_name, b.tag_name));
 
   return releases;
+}
+
+function filterValidReleases(releases: GitHubRelease[]): GitHubRelease[] {
+  return releases.filter(release => {
+    const tag = release.tag_name;
+    return tag.startsWith("v") && semver.valid(tag);
+  });
 }
 
 function chooseRelease(
@@ -97,5 +105,8 @@ export default {
   chooseAsset,
   authenticate,
   addBinDirToPath,
-  installTools
+  installTools,
+  filterValidReleases
 };
+
+export type {GitHubRelease};

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -1,6 +1,6 @@
-import {addPath} from "@actions/core";
-import {exec} from "@actions/exec";
-import {GitHub} from "@actions/github";
+import { addPath } from "@actions/core";
+import { exec } from "@actions/exec";
+import { GitHub } from "@actions/github";
 import semver from "semver";
 import os from "os";
 
@@ -21,7 +21,6 @@ async function getReleases(octokit: GitHub): Promise<GitHubRelease[]> {
   });
 
   let releases = response.data as GitHubRelease[];
-  releases = filterValidReleases(releases);
   releases.sort((a, b) => -semver.compare(a.tag_name, b.tag_name));
 
   return releases;
@@ -109,4 +108,4 @@ export default {
   filterValidReleases
 };
 
-export type {GitHubRelease};
+export type { GitHubRelease };

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -20,7 +20,7 @@ async function getReleases(octokit: GitHub): Promise<GitHubRelease[]> {
     repo: "foreman"
   });
 
-  let releases = response.data as GitHubRelease[];
+  const releases = response.data as GitHubRelease[];
   releases.sort((a, b) => -semver.compare(a.tag_name, b.tag_name));
 
   return releases;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-import {getInput, debug, addPath, setFailed} from "@actions/core";
-import {downloadTool, extractZip} from "@actions/tool-cache";
-import {GitHub} from "@actions/github";
-import {resolve} from "path";
-import {exec} from "@actions/exec";
+import { getInput, debug, addPath, setFailed } from "@actions/core";
+import { downloadTool, extractZip } from "@actions/tool-cache";
+import { GitHub } from "@actions/github";
+import { resolve } from "path";
+import { exec } from "@actions/exec";
 import configFile from "./configFile";
 import foreman from "./foreman";
 
@@ -17,9 +17,10 @@ async function run(): Promise<void> {
 
     const octokit = new GitHub(githubToken);
     const releases = await foreman.getReleases(octokit);
+    const validReleases = foreman.filterValidReleases(releases)
     debug("Choosing release from GitHub API");
 
-    const release = foreman.chooseRelease(versionReq, releases);
+    const release = foreman.chooseRelease(versionReq, validReleases);
     if (release == null) {
       throw new Error(
         `Could not find Foreman release for version ${versionReq}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-import { getInput, debug, addPath, setFailed } from "@actions/core";
-import { downloadTool, extractZip } from "@actions/tool-cache";
-import { GitHub } from "@actions/github";
-import { resolve } from "path";
-import { exec } from "@actions/exec";
+import {getInput, debug, addPath, setFailed} from "@actions/core";
+import {downloadTool, extractZip} from "@actions/tool-cache";
+import {GitHub} from "@actions/github";
+import {resolve} from "path";
+import {exec} from "@actions/exec";
 import configFile from "./configFile";
 import foreman from "./foreman";
 
@@ -14,7 +14,6 @@ async function run(): Promise<void> {
     const allowExternalGithubOrgs: string = getInput(
       "allow-external-github-orgs"
     ).toLowerCase();
-
 
     const octokit = new GitHub(githubToken);
     const releases = await foreman.getReleases(octokit);


### PR DESCRIPTION
The current behavior is for setup-foreman to fail if it encounters an invalid semver tag in the Foreman repo. This PR looks to 
add a filter step to filter out invalid semver tags.