### PR TITLE
Add allow list option to setup-foreman

### DIFF
--- a/__tests__/configFile.test.ts
+++ b/__tests__/configFile.test.ts
@@ -14,7 +14,7 @@ test("checkSameOrgToolSpec same org", () => {
     tool3 = { source = "org1/tool3", version = "1.0.0" }\n
   `;
   let manifestContent = parse(config);
-  expect(configFile.checkSameOrgToolSpecs(manifestContent, "org1")).toEqual(
+  expect(configFile.checkSameOrgToolSpecs(manifestContent, "org1", [])).toEqual(
     true
   );
 });
@@ -27,9 +27,34 @@ test("checkSameOrgToolSpec different org", () => {
     tool3 = { source = "org1/tool3", version = "1.0.0" }\n
   `;
   let manifestContent = parse(config);
-  expect(configFile.checkSameOrgToolSpecs(manifestContent, "org1")).toEqual(
+  expect(configFile.checkSameOrgToolSpecs(manifestContent, "org1", [])).toEqual(
     false
   );
+});
+
+test("checkSameOrgToolSpec external org allowed with allowList", () => {
+  let config = `
+    [tools]\n
+    tool1 = { source = "org1/tool1", version = "1.0.0" }\n
+    tool2 = { source = "org2/tool2", version = "1.0.0" }\n
+    tool3 = { source = "org1/tool3", version = "1.0.0" }\n
+  `;
+  let manifestContent = parse(config);
+  expect(
+    configFile.checkSameOrgToolSpecs(manifestContent, "org1", ["org2"])
+  ).toEqual(true);
+});
+
+test("checkSameOrgToolSpec external org allowed case-insensitive", () => {
+  let config = `
+    [tools]\n
+    tool1 = { source = "org1/tool1", version = "1.0.0" }\n
+    tool2 = { source = "ORG2/tool2", version = "1.0.0" }\n
+  `;
+  let manifestContent = parse(config);
+  expect(
+    configFile.checkSameOrgToolSpecs(manifestContent, "org1", ["org2"])
+  ).toEqual(true);
 });
 
 test("filter valid releases", () => {

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   allow-external-github-orgs:
     required: false
     description: 'Allow installing from external GitHub organizations'
+  github-orgs-allow-list:
+    required: false
+    description: 'Comma separated list of orgs that are allowed even if external orgs are not allowed'
   artifactory-url:
     required: false
     description: 'Artifactory URL to use for downloading Foreman tools'

--- a/src/configFile.ts
+++ b/src/configFile.ts
@@ -18,7 +18,8 @@ const MANIFEST = "foreman.toml";
 
 function checkSameOrgToolSpecs(
   manifestContent: foremanConfig,
-  org: string
+  org: string,
+  allowList: string[]
 ): boolean {
   const tools = manifestContent.tools;
   if (tools == null) {
@@ -44,13 +45,13 @@ function checkSameOrgToolSpecs(
       );
     }
     if (tool_org.toLowerCase() != org) {
-      return false;
+      return allowList.includes(tool_org.toLowerCase())
     }
   }
   return true;
 }
 
-async function checkSameOrgInConfig(org: string): Promise<void> {
+async function checkSameOrgInConfig(org: string, allowList: string[]): Promise<void> {
   const manifestPath = await findUp(MANIFEST);
   if (manifestPath == undefined) {
     throw new Error("setup-foreman could not find Foreman config file");
@@ -63,7 +64,7 @@ async function checkSameOrgInConfig(org: string): Promise<void> {
       );
     }
     const manifestContent = parse(data);
-    const sameGithubOrgSource = checkSameOrgToolSpecs(manifestContent, org);
+    const sameGithubOrgSource = checkSameOrgToolSpecs(manifestContent, org, allowList);
     if (!sameGithubOrgSource) {
       throw new Error(
         `All GitHub orgs in Foreman config must match the org setup-foreman runs in: ${org}. To disable this check, set the \"allow-external-github-orgs\" option to true.`

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,9 @@ async function run(): Promise<void> {
     const allowExternalGithubOrgs: string = getInput(
       "allow-external-github-orgs"
     ).toLowerCase();
+    const githubOrgsAllowList: string[] = getInput(
+      "github-orgs-allow-list"
+    ).split(",").map((org: string) => org.trim().toLowerCase()).filter((org) => org !== "");
     const artifactoryUrl = getInput("artifactory-url");
     const artifactoryToken = getInput("artifactory-token");
 
@@ -85,7 +88,7 @@ async function run(): Promise<void> {
           `Could not find repository owner setup-foreman is running in`
         );
       }
-      configFile.checkSameOrgInConfig(owner.toLowerCase());
+      configFile.checkSameOrgInConfig(owner.toLowerCase(), githubOrgsAllowList);
     }
 
     await foreman.installTools();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2016",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
Organizations may want to enable specific orgs outside of the owner of the current repository. Add an option to allow them.